### PR TITLE
feat: show version on login screen

### DIFF
--- a/MauiApp1/Views/LoginPage.xaml
+++ b/MauiApp1/Views/LoginPage.xaml
@@ -17,13 +17,19 @@
 				   HorizontalOptions="Center" />
             
 			<!-- Title -->
-			<Label Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=AppTitleText}" 
-				   FontSize="32" 
-				   FontAttributes="Bold" 
-				   TextColor="Black" 
-				   HorizontalOptions="Center" />
-            
-			<!-- Email Entry -->
+                        <Label Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=AppTitleText}"
+                                   FontSize="32"
+                                   FontAttributes="Bold"
+                                   TextColor="Black"
+                                   HorizontalOptions="Center" />
+
+                        <!-- Version Label -->
+                        <Label Text="v1"
+                                   FontSize="16"
+                                   TextColor="Black"
+                                   HorizontalOptions="Center" />
+
+                        <!-- Email Entry -->
 			<Frame BackgroundColor="White" BorderColor="Gray" CornerRadius="8">
 				<Entry x:Name="EmailEntry"
 					   Text="{Binding Email}"


### PR DESCRIPTION
## Summary
- display version label on login page

## Testing
- `dotnet build MauiApp1.sln` *(fails: NETSDK1147 workload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a596100b34832b93e2b3e9b2240ca0