### PR TITLE
Add GitHub Action to build Android MAUI app

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,84 @@
+name: Android (MAUI) Build
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'MauiApp1/**'
+      - '.github/workflows/android.yml'
+  workflow_dispatch:
+    inputs:
+      configuration:
+        description: Build configuration
+        required: false
+        default: Release
+      project:
+        description: Relative path to the MAUI project (.csproj)
+        required: false
+        default: MauiApp1/MauiApp1.csproj
+      package_app:
+        description: 'Package .apk/.aab as artifact'
+        required: false
+        default: 'true'
+      package_format:
+        description: 'Android package format (apk or aab)'
+        required: false
+        default: 'aab'
+
+jobs:
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      CONFIG: "${{ github.event.inputs.configuration || 'Release' }}"
+      PROJECT: "${{ github.event.inputs.project || 'MauiApp1/MauiApp1.csproj' }}"
+      PACKAGE_APP: "${{ github.event.inputs.package_app || 'true' }}"
+      PACKAGE_FORMAT: "${{ github.event.inputs.package_format || 'aab' }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install MAUI workload
+        run: |
+          dotnet nuget locals all --clear
+          dotnet workload install maui
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore "$PROJECT"
+
+      - name: Build Android package
+        run: |
+          dotnet publish "$PROJECT" -c "$CONFIG" -f net8.0-android \
+            /p:AndroidPackageFormat=$PACKAGE_FORMAT
+
+      - name: Upload Android artifact
+        if: ${{ env.PACKAGE_APP == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-${{ env.PACKAGE_FORMAT }}
+          path: |
+            **/bin/${{ env.CONFIG }}/net8.0-android/*.$PACKAGE_FORMAT
+          if-no-files-found: warn
+
+      - name: List Android outputs
+        if: ${{ env.PACKAGE_APP == 'true' }}
+        run: |
+          echo "Listing Android outputs:"
+          find . -type f -path "*/bin/${CONFIG}/net8.0-android/*" -print || true


### PR DESCRIPTION
## Summary
- add workflow to build and package the MAUI project for Android on GitHub Actions

## Testing
- `dotnet build MauiApp1/MauiApp1.csproj -t:Restore` *(fails: The target platform identifier ios was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a5996fbf78832b9c605dc5d6d6adc2